### PR TITLE
Invoke-SqlScripts was not referencing the global defaults for DbServe…

### DIFF
--- a/hqTestLite.psm1
+++ b/hqTestLite.psm1
@@ -8,11 +8,9 @@ function Invoke-SqlScripts {
     [CmdletBinding(SupportsShouldProcess = $True, PositionalBinding = $False)]
 
     Param(
-        [Parameter(Mandatory = $True)]
-        [string]$DbServer,
+        [string]$DbServer = $Global:DefaultMedmDbServer,
 
-        [Parameter(Mandatory = $True)]
-        [string]$DbName,
+        [string]$DbName = $Global:DefaultMedmDbName,
 
         [string]$SqlDir = $null,
 


### PR DESCRIPTION
See the commit message. Simple change I think